### PR TITLE
feat: build second brain dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/node_modules
+/.next
+/.turbo
+.env*
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env.local
+.supabase

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Second Brain Dashboard
+
+A secure, Notion-inspired personal operating system built with Next.js 14, Supabase, Tailwind CSS, shadcn/ui primitives, and SWR. Designed to deploy on Vercel with a Supabase backend and embeddable at `dash.bansalpatel.com` (use the `/embed` route for clean iframes).
+
+## Getting started
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Create a `.env.local` with Supabase credentials:
+   ```bash
+   NEXT_PUBLIC_SUPABASE_URL=...
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+   SUPABASE_SERVICE_ROLE_KEY=...
+   ```
+3. Run database migration in Supabase SQL editor using `supabase/migrations/0001_create_schema.sql`.
+4. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+
+## Features
+
+- Supabase Auth with passwordless magic links (Cloudflare Access friendly) and middleware enforced routes.
+- Drag-and-drop configurable dashboard tiles persisted per user profile.
+- Widgets for daily overview, tasks, habits, mood logging, training logs, civic admin, and external embeds.
+- `/embed` layout optimized for iframe embedding on the solo website.
+- Type-safe Supabase helpers and RLS policies for every table.
+
+## Deployment
+
+Deploy the Next.js app to Vercel. Point `dash.bansalpatel.com` to the Vercel project and configure Supabase URL/keys in project environment variables. Use the same build on the Solo site via `<iframe src="https://dash.bansalpatel.com/embed" />`.

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "next/navigation";
+import { getSupabaseServerClient } from "../../lib/supabase/server";
+import { AuthForm } from "../../components/auth-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function LoginPage() {
+  const supabase = getSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (session) {
+    redirect("/");
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-6">
+      <div className="mx-auto w-full max-w-md space-y-6 rounded-2xl border border-border bg-card p-8 shadow-lg">
+        <h1 className="text-2xl font-semibold">Secure Sign In</h1>
+        <p className="text-sm text-muted-foreground">
+          Use your email address to receive a magic link. Supabase Auth powers
+          secure passwordless access and works with Cloudflare Access.
+        </p>
+        <AuthForm />
+      </div>
+    </div>
+  );
+}

--- a/app/api/habits/log/route.ts
+++ b/app/api/habits/log/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseRouteClient } from "../../../../lib/supabase/route";
+
+export async function POST(req: NextRequest) {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { habit_id, qty } = body;
+
+  const { data, error } = await supabase
+    .from("habit_logs")
+    .insert({ habit_id, qty, user_id: user.id })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ log: data });
+}

--- a/app/api/habits/route.ts
+++ b/app/api/habits/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseRouteClient } from "../../../lib/supabase/route";
+
+export async function GET() {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: habits, error } = await supabase
+    .from("habits")
+    .select("*")
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  const since = new Date();
+  since.setDate(since.getDate() - 7);
+
+  const { data: logs, error: logError } = await supabase
+    .from("habit_logs")
+    .select("*")
+    .gte("ts", since.toISOString())
+    .order("ts", { ascending: false });
+
+  if (logError) {
+    return NextResponse.json({ error: logError.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ habits, logs });
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { name, goal_per_day } = body;
+
+  const { data, error } = await supabase
+    .from("habits")
+    .insert({ name, goal_per_day, user_id: user.id })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ habit: data });
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ status: "ok" });
+}

--- a/app/api/moods/route.ts
+++ b/app/api/moods/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseRouteClient } from "../../../lib/supabase/route";
+
+export async function GET() {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("moods")
+    .select("*")
+    .order("ts", { ascending: false })
+    .limit(30);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ moods: data });
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { score, note } = body;
+
+  const { data, error } = await supabase
+    .from("moods")
+    .insert({ score, note, user_id: user.id })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ mood: data });
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseRouteClient } from "../../../lib/supabase/route";
+
+export async function GET() {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("tasks")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ tasks: data });
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { title, due_date, status } = body;
+
+  const { data, error } = await supabase
+    .from("tasks")
+    .insert({
+      title,
+      due_date,
+      status,
+      user_id: user.id,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ task: data });
+}
+
+export async function PATCH(req: NextRequest) {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { id, ...updates } = body;
+
+  if (!id) {
+    return NextResponse.json({ error: "Missing task id" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("tasks")
+    .update(updates)
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ task: data });
+}

--- a/app/api/widgets/route.ts
+++ b/app/api/widgets/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseRouteClient } from "../../../lib/supabase/route";
+
+export async function GET() {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("widgets")
+    .eq("id", user.id)
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({
+    widgets:
+      data.widgets ?? {
+        order: ["today", "tasks", "habits", "gym", "mood", "civil", "embeds"],
+        hidden: [],
+        settings: {},
+      },
+  });
+}
+
+export async function PUT(req: NextRequest) {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const payload = await req.json();
+  const nextWidgets = {
+    order: Array.isArray(payload.order) ? payload.order : [],
+    hidden: Array.isArray(payload.hidden) ? payload.hidden : [],
+    settings:
+      typeof payload.settings === "object" && payload.settings !== null
+        ? payload.settings
+        : {},
+  };
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ widgets: nextWidgets })
+    .eq("id", user.id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/workouts/route.ts
+++ b/app/api/workouts/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseRouteClient } from "../../../lib/supabase/route";
+
+export async function GET() {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from("workouts")
+    .select("*, workout_sets(*)")
+    .order("ts", { ascending: false })
+    .limit(10);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ workouts: data });
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = getSupabaseRouteClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { ts, bodypart, notes, sets } = body;
+
+  const { data: workout, error } = await supabase
+    .from("workouts")
+    .insert({
+      ts,
+      bodypart,
+      notes,
+      user_id: user.id,
+    })
+    .select()
+    .single();
+
+  if (error || !workout) {
+    return NextResponse.json({ error: error?.message ?? "Unknown error" }, { status: 400 });
+  }
+
+  if (Array.isArray(sets) && sets.length > 0) {
+    const { error: setError } = await supabase.from("workout_sets").insert(
+      sets.map((set: any) => ({ ...set, workout_id: workout.id }))
+    );
+
+    if (setError) {
+      return NextResponse.json({ error: setError.message }, { status: 400 });
+    }
+  }
+
+  const { data: enriched } = await supabase
+    .from("workouts")
+    .select("*, workout_sets(*)")
+    .eq("id", workout.id)
+    .single();
+
+  return NextResponse.json({ workout: enriched ?? workout });
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from "../../types/database";
+import { cookies } from "next/headers";
+
+export async function GET(req: NextRequest) {
+  const requestUrl = new URL(req.url);
+  const code = requestUrl.searchParams.get("code");
+  const next = requestUrl.searchParams.get("next") ?? "/";
+  const redirectTo = new URL(next, requestUrl.origin);
+  const supabase = createRouteHandlerClient<Database>({ cookies });
+
+  if (code) {
+    await supabase.auth.exchangeCodeForSession(code);
+  }
+
+  return NextResponse.redirect(redirectTo);
+}

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -1,0 +1,59 @@
+import { redirect } from "next/navigation";
+import { getSupabaseServerClient } from "../../lib/supabase/server";
+import Dashboard from "../../components/dashboard";
+
+export const dynamic = "force-dynamic";
+
+export default async function EmbedPage() {
+  const supabase = getSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  let { data: profile } = await supabase
+    .from("profiles")
+    .select("widgets, tz, email")
+    .eq("id", session.user.id)
+    .maybeSingle();
+
+  if (!profile) {
+    const { data: created } = await supabase
+      .from("profiles")
+      .upsert({
+        id: session.user.id,
+        email: session.user.email,
+      })
+      .select("widgets, tz, email")
+      .single();
+    profile = created ?? null;
+  }
+
+  const widgets =
+    (profile?.widgets as {
+      order: string[];
+      hidden: string[];
+      settings?: Record<string, unknown>;
+    } | null) ?? {
+      order: ["today", "tasks", "habits", "gym", "mood", "civil", "embeds"],
+      hidden: [],
+      settings: {},
+    };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Dashboard
+        session={session}
+        profile={{
+          tz: profile?.tz ?? "America/New_York",
+          email: profile?.email ?? session.user.email ?? "",
+          widgets,
+        }}
+        mode="embed"
+      />
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import "../styles/globals.css";
+import { ReactNode } from "react";
+import { Providers } from "../components/providers";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Second Brain Dashboard",
+  description: "Notion-style personal command center",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,56 @@
+import { redirect } from "next/navigation";
+import { getSupabaseServerClient } from "../lib/supabase/server";
+import Dashboard from "../components/dashboard";
+
+export const dynamic = "force-dynamic";
+
+export default async function HomePage() {
+  const supabase = getSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  let { data: profile } = await supabase
+    .from("profiles")
+    .select("widgets, tz, email")
+    .eq("id", session.user.id)
+    .maybeSingle();
+
+  if (!profile) {
+    const { data: created } = await supabase
+      .from("profiles")
+      .upsert({
+        id: session.user.id,
+        email: session.user.email,
+      })
+      .select("widgets, tz, email")
+      .single();
+    profile = created ?? null;
+  }
+
+  const widgets =
+    (profile?.widgets as {
+      order: string[];
+      hidden: string[];
+      settings?: Record<string, unknown>;
+    } | null) ?? {
+      order: ["today", "tasks", "habits", "gym", "mood", "civil", "embeds"],
+      hidden: [],
+      settings: {},
+    };
+
+  return (
+    <Dashboard
+      session={session}
+      profile={{
+        tz: profile?.tz ?? "America/New_York",
+        email: profile?.email ?? session.user.email ?? "",
+        widgets,
+      }}
+    />
+  );
+}

--- a/components/auth-form.tsx
+++ b/components/auth-form.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { createClient } from "../lib/supabase/client";
+import { Button } from "./ui/button";
+
+export function AuthForm() {
+  const supabase = useMemo(() => createClient(), []);
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setLoading(true);
+    setMessage(null);
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+    if (error) {
+      setMessage(error.message);
+    } else {
+      setMessage("Check your inbox for a secure login link.");
+    }
+    setLoading(false);
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor="email">
+          Work or personal email
+        </label>
+        <input
+          id="email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          placeholder="you@bansalpatel.com"
+        />
+      </div>
+      <Button className="w-full" type="submit" disabled={loading}>
+        {loading ? "Sending..." : "Send magic link"}
+      </Button>
+      {message && <p className="text-sm text-muted-foreground">{message}</p>}
+    </form>
+  );
+}

--- a/components/dashboard-context.tsx
+++ b/components/dashboard-context.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+interface DashboardContextValue {
+  tz: string;
+  email: string;
+  widgetSettings: Record<string, any>;
+  updateWidgetSettings: (next: Record<string, any>) => void;
+}
+
+export const DashboardContext = createContext<DashboardContextValue | null>(
+  null
+);
+
+export function useDashboard() {
+  const ctx = useContext(DashboardContext);
+  if (!ctx) {
+    throw new Error("useDashboard must be used inside DashboardContext");
+  }
+  return ctx;
+}

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import type { Session } from "@supabase/supabase-js";
+import { Button } from "./ui/button";
+import { Settings, LogOut } from "lucide-react";
+import { widgetRegistry, WidgetKey, getWidgetById } from "./widgets/registry";
+import { SortableWidget } from "./widgets/sortable-widget";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Badge } from "./ui/badge";
+import { DashboardContext } from "./dashboard-context";
+import { cn } from "../lib/utils";
+import { createClient } from "../lib/supabase/client";
+
+interface DashboardProps {
+  session: Session;
+  profile: {
+    tz: string;
+    email: string;
+    widgets: { order: string[]; hidden: string[]; settings?: Record<string, any> };
+  };
+  mode?: "app" | "embed";
+}
+
+export default function Dashboard({
+  session: _session,
+  profile,
+  mode = "app",
+}: DashboardProps) {
+  const supabase = useMemo(() => createClient(), []);
+  const [orderedWidgets, setOrderedWidgets] = useState<WidgetKey[]>(
+    profile.widgets.order as WidgetKey[]
+  );
+  const [hiddenWidgets, setHiddenWidgets] = useState<WidgetKey[]>(
+    profile.widgets.hidden as WidgetKey[]
+  );
+  const [widgetSettings, setWidgetSettings] = useState<Record<string, any>>(
+    profile.widgets.settings ?? {}
+  );
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  useEffect(() => {
+    setOrderedWidgets(profile.widgets.order as WidgetKey[]);
+    setHiddenWidgets(profile.widgets.hidden as WidgetKey[]);
+    setWidgetSettings(profile.widgets.settings ?? {});
+  }, [profile.widgets]);
+
+  const visibleWidgets = orderedWidgets.filter(
+    (widget) => !hiddenWidgets.includes(widget)
+  );
+
+  async function persistWidgets(
+    nextOrder: WidgetKey[],
+    nextHidden: WidgetKey[],
+    nextSettings = widgetSettings
+  ) {
+    await fetch("/api/widgets", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        order: nextOrder,
+        hidden: nextHidden,
+        settings: nextSettings,
+      }),
+    });
+  }
+
+  function handleDragEnd(event: any) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = orderedWidgets.indexOf(active.id as WidgetKey);
+    const newIndex = orderedWidgets.indexOf(over.id as WidgetKey);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const next = arrayMove(orderedWidgets, oldIndex, newIndex) as WidgetKey[];
+    setOrderedWidgets(next);
+    persistWidgets(next, hiddenWidgets);
+  }
+
+  function toggleWidget(id: WidgetKey) {
+    const isHidden = hiddenWidgets.includes(id);
+    const nextHidden = isHidden
+      ? hiddenWidgets.filter((widget) => widget !== id)
+      : [...hiddenWidgets, id];
+    setHiddenWidgets(nextHidden);
+    persistWidgets(orderedWidgets, nextHidden);
+  }
+
+  async function signOut() {
+    await supabase.auth.signOut();
+    window.location.href = "/login";
+  }
+
+  function handleWidgetSettings(next: Record<string, any>) {
+    setWidgetSettings(next);
+    persistWidgets(orderedWidgets, hiddenWidgets, next);
+  }
+
+  return (
+    <DashboardContext.Provider
+      value={{
+        tz: profile.tz,
+        email: profile.email,
+        widgetSettings,
+        updateWidgetSettings: handleWidgetSettings,
+      }}
+    >
+      <div
+        className={cn(
+          "min-h-screen",
+          mode === "embed"
+            ? "bg-transparent"
+            : "bg-gradient-to-br from-background via-background to-muted"
+        )}
+      >
+        {mode === "app" && (
+          <header className="sticky top-0 z-20 border-b border-border bg-background/90 backdrop-blur">
+            <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
+              <div>
+                <p className="text-sm text-muted-foreground">Signed in as</p>
+                <h1 className="text-xl font-semibold">{profile.email}</h1>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="ghost"
+                  className="gap-2"
+                  onClick={() => setSettingsOpen((prev) => !prev)}
+                >
+                  <Settings className="h-4 w-4" /> Customize
+                </Button>
+                <Button variant="outline" onClick={signOut} className="gap-2">
+                  <LogOut className="h-4 w-4" />
+                  Sign out
+                </Button>
+              </div>
+            </div>
+          </header>
+        )}
+        <main
+          className={cn(
+            "mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-6",
+            mode === "embed" && "px-0"
+          )}
+        >
+          {settingsOpen && mode === "app" && (
+            <Card className="border-dashed">
+              <CardHeader className="flex flex-col gap-2">
+                <CardTitle>Dashboard layout</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Drag tiles to reorder. Toggle visibility per tile. Changes
+                  sync instantly to Supabase so every device stays aligned.
+                </p>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {widgetRegistry.map((widget) => {
+                  const hidden = hiddenWidgets.includes(widget.id);
+                  return (
+                    <button
+                      key={widget.id}
+                      onClick={() => toggleWidget(widget.id)}
+                      className={cn(
+                        "rounded-full border px-3 py-1 text-sm transition",
+                        hidden
+                          ? "border-dashed border-muted-foreground/60 text-muted-foreground"
+                          : "border-border bg-secondary/40"
+                      )}
+                    >
+                      {widget.name}
+                      {hidden && <span className="ml-2 text-xs">(hidden)</span>}
+                    </button>
+                  );
+                })}
+              </CardContent>
+            </Card>
+          )}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+            modifiers={[restrictToVerticalAxis]}
+          >
+            <SortableContext items={visibleWidgets} strategy={verticalListSortingStrategy}>
+              <div className="grid gap-4 lg:grid-cols-2">
+                {visibleWidgets.map((id) => {
+                  const widget = getWidgetById(id);
+                  if (!widget) return null;
+                  const WidgetComponent = widget.component;
+                  return (
+                    <SortableWidget key={widget.id} id={widget.id}>
+                      <Card className="h-full">
+                        <CardHeader className="flex items-start justify-between">
+                          <div>
+                            <CardTitle>{widget.name}</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                              {widget.description}
+                            </p>
+                          </div>
+                          <Badge variant="outline">Drag</Badge>
+                        </CardHeader>
+                        <CardContent>
+                          <WidgetComponent />
+                        </CardContent>
+                      </Card>
+                    </SortableWidget>
+                  );
+                })}
+              </div>
+            </SortableContext>
+          </DndContext>
+        </main>
+      </div>
+    </DashboardContext.Provider>
+  );
+}

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createBrowserSupabaseClient } from "@supabase/auth-helpers-nextjs";
+import { SessionContextProvider } from "@supabase/auth-helpers-react";
+import { ThemeProvider } from "next-themes";
+import { ReactNode, useState } from "react";
+import { Database } from "../types/database";
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [supabase] = useState(() =>
+    createBrowserSupabaseClient<Database>()
+  );
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <SessionContextProvider supabaseClient={supabase}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </SessionContextProvider>
+    </ThemeProvider>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-transparent px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "bg-secondary text-secondary-foreground",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-xl border border-border bg-card text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3 ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+export { Card, CardHeader, CardTitle, CardContent };

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,10 @@
+import { cn } from "../../lib/utils";
+
+export function Separator({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn("h-px w-full bg-border", className)}
+      aria-hidden="true"
+    />
+  );
+}

--- a/components/widgets/civil-widget.tsx
+++ b/components/widgets/civil-widget.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import useSWR from "swr";
+import { parseISO, differenceInCalendarDays } from "date-fns";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function CivilWidget() {
+  const { data } = useSWR<{ tasks: any[] }>("/api/tasks", fetcher);
+  const upcoming = (data?.tasks ?? [])
+    .filter((task) => task.due_date && task.status !== "done")
+    .map((task) => ({
+      ...task,
+      days: differenceInCalendarDays(parseISO(task.due_date), new Date()),
+    }))
+    .sort((a, b) => a.days - b.days)
+    .slice(0, 5);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-background/40 p-4 text-sm text-muted-foreground">
+        Sync this tile with civic obligations: passport renewals, taxes,
+        vehicle inspections, or family admin tasks. Use the Supabase Tasks table
+        to schedule reminders and they will surface here automatically.
+      </div>
+      <div className="space-y-2">
+        {upcoming.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No upcoming admin tasks. Add due dates to tasks to populate this
+            feed.
+          </p>
+        )}
+        {upcoming.map((task) => (
+          <div
+            key={task.id}
+            className="flex items-center justify-between rounded-lg border border-border bg-background/80 px-3 py-2 text-sm"
+          >
+            <span className="font-medium">{task.title}</span>
+            <span className="text-xs text-muted-foreground">
+              {task.days <= 0 ? "Due" : `${task.days}d`}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/widgets/embeds-widget.tsx
+++ b/components/widgets/embeds-widget.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { useDashboard } from "../dashboard-context";
+import { Button } from "../ui/button";
+
+interface EmbedConfig {
+  title: string;
+  url: string;
+}
+
+export function EmbedsWidget() {
+  const { widgetSettings, updateWidgetSettings } = useDashboard();
+  const embeds: EmbedConfig[] = widgetSettings.embeds ?? [];
+  const [title, setTitle] = useState("");
+  const [url, setUrl] = useState("");
+
+  function addEmbed(event: React.FormEvent) {
+    event.preventDefault();
+    if (!url) return;
+    const nextEmbeds = [...embeds, { title: title || url, url }];
+    updateWidgetSettings({ ...widgetSettings, embeds: nextEmbeds });
+    setTitle("");
+    setUrl("");
+  }
+
+  function removeEmbed(index: number) {
+    const nextEmbeds = embeds.filter((_, idx) => idx !== index);
+    updateWidgetSettings({ ...widgetSettings, embeds: nextEmbeds });
+  }
+
+  return (
+    <div className="space-y-4">
+      <form
+        onSubmit={addEmbed}
+        className="grid gap-2 md:grid-cols-[1fr_2fr_auto]"
+      >
+        <input
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          placeholder="Label"
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <input
+          value={url}
+          onChange={(event) => setUrl(event.target.value)}
+          placeholder="https://..."
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <Button type="submit">Add</Button>
+      </form>
+      <p className="text-xs text-muted-foreground">
+        Embed dashboards (e.g., Linear, Fathom, Supabase) that allow iframe
+        embedding. On the public site, use the `/embed` route for a clean layout.
+      </p>
+      <div className="space-y-4">
+        {embeds.length === 0 && (
+          <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-background/40 p-4 text-sm text-muted-foreground">
+            No embeds yet. Add secure URLs above. Only authenticated sessions can
+            view them.
+          </div>
+        )}
+        {embeds.map((embed, index) => (
+          <div key={index} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <p className="font-medium">{embed.title}</p>
+              <button
+                type="button"
+                className="text-xs uppercase text-destructive"
+                onClick={() => removeEmbed(index)}
+              >
+                Remove
+              </button>
+            </div>
+            <div className="overflow-hidden rounded-xl border border-border">
+              <iframe
+                src={embed.url}
+                title={embed.title}
+                className="h-64 w-full"
+                sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/widgets/gym-widget.tsx
+++ b/components/widgets/gym-widget.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import useSWR from "swr";
+import { format } from "date-fns";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function GymWidget() {
+  const { data } = useSWR<{ workouts: any[] }>("/api/workouts", fetcher, {
+    refreshInterval: 120_000,
+  });
+  const workouts = data?.workouts ?? [];
+
+  return (
+    <div className="space-y-4">
+      {workouts.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          Log your training sessions to see them here. Capture notes per body
+          part and detail individual sets.
+        </p>
+      )}
+      <div className="space-y-3">
+        {workouts.map((workout) => (
+          <div
+            key={workout.id}
+            className="space-y-2 rounded-xl border border-border bg-background/40 p-4"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <p className="font-semibold">
+                  {workout.bodypart || "Full body"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {format(
+                    new Date(workout.ts ?? Date.now()),
+                    "MMM d, yyyy 'at' h:mm a"
+                  )}
+                </p>
+              </div>
+              {workout.notes && (
+                <p className="max-w-xs text-sm text-muted-foreground">
+                  {workout.notes}
+                </p>
+              )}
+            </div>
+            <div className="space-y-1 text-xs">
+              {(workout.workout_sets || []).map((set: any, idx: number) => (
+                <div
+                  key={`${workout.id}-${idx}`}
+                  className="flex items-center justify-between rounded-md bg-muted/60 px-3 py-1"
+                >
+                  <span className="font-medium">{set.lift}</span>
+                  <span>
+                    {set.weight ? `${set.weight} lb` : "BW"} × {set.reps} reps
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/widgets/habits-widget.tsx
+++ b/components/widgets/habits-widget.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import useSWR from "swr";
+import { Button } from "../ui/button";
+import { format } from "date-fns";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function HabitsWidget() {
+  const { data, mutate } = useSWR<{ habits: any[]; logs: any[] }>(
+    "/api/habits",
+    fetcher,
+    { refreshInterval: 60_000 }
+  );
+
+  const habits = data?.habits ?? [];
+  const logs = data?.logs ?? [];
+  const todayKey = new Date().toISOString().slice(0, 10);
+
+  async function logHabit(habitId: string) {
+    await fetch("/api/habits/log", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ habit_id: habitId, qty: 1 }),
+    });
+    mutate();
+  }
+
+  return (
+    <div className="space-y-4">
+      {habits.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          Create habits from Supabase directly or via admin UI. Once added, you
+          can track progress from here.
+        </p>
+      )}
+      <div className="space-y-3">
+        {habits.map((habit) => {
+          const habitLogs = logs.filter((log) => log.habit_id === habit.id);
+          const todayCount = habitLogs
+            .filter((log) => (log.ts ?? "").slice(0, 10) === todayKey)
+            .reduce((acc, log) => acc + (log.qty ?? 1), 0);
+          const completionRatio = Math.min(
+            1,
+            todayCount / (habit.goal_per_day || 1)
+          );
+          return (
+            <div
+              key={habit.id}
+              className="space-y-2 rounded-lg border border-border bg-background/50 p-4"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-semibold">{habit.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Goal: {habit.goal_per_day} per day • Today: {todayCount}
+                  </p>
+                </div>
+                <Button size="sm" onClick={() => logHabit(habit.id)}>
+                  +1
+                </Button>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-primary transition-all"
+                  style={{ width: `${completionRatio * 100}%` }}
+                />
+              </div>
+              <div className="flex gap-2 text-xs text-muted-foreground">
+                {habitLogs.slice(0, 5).map((log) => (
+                  <span key={log.id} className="rounded-full bg-secondary px-2 py-1">
+                    {format(new Date(log.ts ?? Date.now()), "EEE")}: +{log.qty}
+                  </span>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/widgets/mood-widget.tsx
+++ b/components/widgets/mood-widget.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { format } from "date-fns";
+import { Button } from "../ui/button";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+const moodsScale = [
+  { score: 1, label: "Low" },
+  { score: 2, label: "Meh" },
+  { score: 3, label: "Okay" },
+  { score: 4, label: "Good" },
+  { score: 5, label: "Peak" },
+];
+
+export function MoodWidget() {
+  const { data, mutate } = useSWR<{ moods: any[] }>("/api/moods", fetcher, {
+    refreshInterval: 120_000,
+  });
+  const [note, setNote] = useState("");
+
+  async function logMood(score: number) {
+    await fetch("/api/moods", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score, note }),
+    });
+    setNote("");
+    mutate();
+  }
+
+  const moods = data?.moods ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <textarea
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+          placeholder="Add a quick reflection"
+          rows={2}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <div className="flex flex-wrap gap-2">
+          {moodsScale.map((mood) => (
+            <Button key={mood.score} size="sm" onClick={() => logMood(mood.score)}>
+              {mood.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        {moods.slice(0, 7).map((entry) => (
+          <div
+            key={entry.id}
+            className="flex items-center justify-between rounded-lg border border-border bg-background/60 px-3 py-2 text-sm"
+          >
+            <div>
+              <p className="font-medium">Score {entry.score}</p>
+              {entry.note && (
+                <p className="text-xs text-muted-foreground">{entry.note}</p>
+              )}
+            </div>
+            <span className="text-xs text-muted-foreground">
+              {format(new Date(entry.ts ?? Date.now()), "MMM d, h:mma")}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/widgets/registry.tsx
+++ b/components/widgets/registry.tsx
@@ -1,0 +1,73 @@
+import { ComponentType } from "react";
+import { TodayWidget } from "./today-widget";
+import { TasksWidget } from "./tasks-widget";
+import { HabitsWidget } from "./habits-widget";
+import { GymWidget } from "./gym-widget";
+import { MoodWidget } from "./mood-widget";
+import { CivilWidget } from "./civil-widget";
+import { EmbedsWidget } from "./embeds-widget";
+
+export type WidgetKey =
+  | "today"
+  | "tasks"
+  | "habits"
+  | "gym"
+  | "mood"
+  | "civil"
+  | "embeds";
+
+export interface WidgetDefinition {
+  id: WidgetKey;
+  name: string;
+  description: string;
+  component: ComponentType;
+}
+
+export const widgetRegistry: WidgetDefinition[] = [
+  {
+    id: "today",
+    name: "Today",
+    description: "Time, weather highlights, and focus for the day.",
+    component: TodayWidget,
+  },
+  {
+    id: "tasks",
+    name: "Tasks",
+    description: "Your actionable todos sorted by state and due date.",
+    component: TasksWidget,
+  },
+  {
+    id: "habits",
+    name: "Habits",
+    description: "Track daily habit completions and streaks.",
+    component: HabitsWidget,
+  },
+  {
+    id: "gym",
+    name: "Training",
+    description: "Recent workouts and logged sets.",
+    component: GymWidget,
+  },
+  {
+    id: "mood",
+    name: "Mood",
+    description: "Log and visualize your emotional state.",
+    component: MoodWidget,
+  },
+  {
+    id: "civil",
+    name: "Civil",
+    description: "Meetings, civic reminders, and personal admin.",
+    component: CivilWidget,
+  },
+  {
+    id: "embeds",
+    name: "Embeds",
+    description: "Surface external dashboards with secure embeds.",
+    component: EmbedsWidget,
+  },
+];
+
+export function getWidgetById(id: WidgetKey) {
+  return widgetRegistry.find((widget) => widget.id === id);
+}

--- a/components/widgets/sortable-widget.tsx
+++ b/components/widgets/sortable-widget.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { PropsWithChildren } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+export function SortableWidget({ id, children }: PropsWithChildren<{ id: string }>) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  } as React.CSSProperties;
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {children}
+    </div>
+  );
+}

--- a/components/widgets/tasks-widget.tsx
+++ b/components/widgets/tasks-widget.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { format, parseISO } from "date-fns";
+import { Button } from "../ui/button";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function TasksWidget() {
+  const { data, mutate } = useSWR<{ tasks: any[] }>("/api/tasks", fetcher);
+  const [title, setTitle] = useState("");
+  const [dueDate, setDueDate] = useState<string>("");
+
+  async function addTask(event: React.FormEvent) {
+    event.preventDefault();
+    if (!title) return;
+    await fetch("/api/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title, due_date: dueDate || null }),
+    });
+    setTitle("");
+    setDueDate("");
+    mutate();
+  }
+
+  const tasks = data?.tasks ?? [];
+  const sections: Record<string, any[]> = {
+    todo: [],
+    doing: [],
+    done: [],
+  };
+  tasks.forEach((task) => {
+    sections[task.status]?.push(task);
+  });
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={addTask} className="grid gap-2 md:grid-cols-[1fr_auto_auto]">
+        <input
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          placeholder="Capture a new task"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+        />
+        <input
+          type="date"
+          value={dueDate}
+          onChange={(event) => setDueDate(event.target.value)}
+          className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <Button type="submit">Add</Button>
+      </form>
+      <div className="grid gap-4 md:grid-cols-3">
+        {Object.entries(sections).map(([status, list]) => (
+          <div key={status} className="space-y-3">
+            <div>
+              <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+                {status}
+              </h3>
+              <p className="text-xs text-muted-foreground">{list.length} items</p>
+            </div>
+            <div className="space-y-2">
+              {list.length === 0 && (
+                <p className="text-xs text-muted-foreground">Nothing here yet.</p>
+              )}
+              {list.map((task) => (
+                <TaskRow key={task.id} task={task} onUpdate={() => mutate()} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TaskRow({ task, onUpdate }: { task: any; onUpdate: () => void }) {
+  const statusCycle = ["todo", "doing", "done"] as const;
+  const nextStatus = statusCycle[(statusCycle.indexOf(task.status) + 1) % statusCycle.length];
+
+  async function advance() {
+    await fetch("/api/tasks", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: task.id, status: nextStatus }),
+    });
+    onUpdate();
+  }
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-border bg-background/60 px-3 py-2 text-sm shadow-sm">
+      <div>
+        <p className="font-medium">{task.title}</p>
+        {task.due_date && (
+          <p className="text-xs text-muted-foreground">
+            due {format(parseISO(task.due_date), "MMM d")}
+          </p>
+        )}
+      </div>
+      <button
+        onClick={advance}
+        className="text-xs uppercase text-primary underline-offset-2 hover:underline"
+      >
+        {task.status === "done" ? "Reset" : "Move to " + nextStatus}
+      </button>
+    </div>
+  );
+}

--- a/components/widgets/today-widget.tsx
+++ b/components/widgets/today-widget.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import useSWR from "swr";
+import { parseISO } from "date-fns";
+import { useDashboard } from "../dashboard-context";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function TodayWidget() {
+  const { tz } = useDashboard();
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const { data: tasksData } = useSWR<{ tasks: any[] }>("/api/tasks", fetcher, {
+    refreshInterval: 60_000,
+  });
+
+  const openTasks = tasksData?.tasks ?? [];
+  const dueToday = openTasks.filter((task) => {
+    if (!task.due_date) return false;
+    const due = parseISO(task.due_date);
+    const today = new Date();
+    return (
+      due.getFullYear() === today.getFullYear() &&
+      due.getMonth() === today.getMonth() &&
+      due.getDate() === today.getDate()
+    );
+  });
+  const overdue = openTasks.filter((task) => {
+    if (!task.due_date || task.status === "done") return false;
+    const due = parseISO(task.due_date);
+    const today = new Date();
+    return due < today && !isSameDay(due, today);
+  });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm uppercase text-muted-foreground">Local time</p>
+        <h2 className="text-3xl font-semibold">{formatter.format(now)}</h2>
+        <p className="text-sm text-muted-foreground">Timezone: {tz}</p>
+      </div>
+      <div className="grid grid-cols-3 gap-3 text-center">
+        <StatCard label="Open" value={openTasks.length} tone="default" />
+        <StatCard label="Due today" value={dueToday.length} tone="accent" />
+        <StatCard label="Overdue" value={overdue.length} tone="alert" />
+      </div>
+    </div>
+  );
+}
+
+function isSameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "default" | "accent" | "alert";
+}) {
+  const toneClass =
+    tone === "accent"
+      ? "bg-primary/10 text-primary"
+      : tone === "alert"
+      ? "bg-destructive/10 text-destructive"
+      : "bg-secondary/60 text-foreground";
+  return (
+    <div className={`rounded-lg ${toneClass} px-4 py-3`}
+    >
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <p className="text-2xl font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+"use client";
+
+import { createBrowserSupabaseClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from "../../types/database";
+
+export function createClient() {
+  return createBrowserSupabaseClient<Database>();
+}

--- a/lib/supabase/route.ts
+++ b/lib/supabase/route.ts
@@ -1,0 +1,7 @@
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from "../../types/database";
+
+export function getSupabaseRouteClient() {
+  return createRouteHandlerClient<Database>({ cookies });
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,10 @@
+import { cookies, headers } from "next/headers";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from "../../types/database";
+
+export function getSupabaseServerClient() {
+  return createServerComponentClient<Database>({
+    cookies,
+    headers,
+  });
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,33 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createMiddlewareClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from "./types/database";
+
+const PUBLIC_PATHS = ["/login", "/auth/callback", "/api/health"];
+
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+  const supabase = createMiddlewareClient<Database>({ req, res });
+
+  await supabase.auth.getSession();
+
+  const isPublic = PUBLIC_PATHS.some((path) => req.nextUrl.pathname.startsWith(path));
+
+  if (!isPublic) {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session) {
+      const redirectUrl = req.nextUrl.clone();
+      redirectUrl.pathname = "/login";
+      redirectUrl.searchParams.set("redirectedFrom", req.nextUrl.pathname);
+      return NextResponse.redirect(redirectUrl);
+    }
+  }
+
+  return res;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true,
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "second-brain",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/modifiers": "^6.0.0",
+    "@dnd-kit/sortable": "^7.0.0",
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
+    "@supabase/supabase-js": "^2.44.0",
+    "@tanstack/react-query": "^5.29.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "date-fns": "^3.6.0",
+    "lucide-react": "^0.368.0",
+    "next": "14.1.0",
+    "next-themes": "^0.3.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "^2.2.4",
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss-animate": "^1.0.7",
+    "@radix-ui/react-slot": "^1.0.3",
+    "@supabase/auth-helpers-react": "^0.5.0",
+    "@dnd-kit/utilities": "^3.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.3.3"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/readme
+++ b/readme
@@ -1,7 +1,0 @@
-git init
-git add -A
-git commit -m "init"
-git branch -M main
-git remote add origin https://github.com/<you>/<repo>.git
-git push -u origin main
-

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,62 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 47.4% 11.2%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 47.4% 11.2%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --ring: 215 20.2% 65.1%;
+  --radius: 0.75rem;
+}
+
+.dark {
+  --background: 222.2 47.4% 11.2%;
+  --foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --popover: 222.2 47.4% 11.2%;
+  --popover-foreground: 210 40% 98%;
+  --card: 222.2 47.4% 11.2%;
+  --card-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --primary: 210 40% 98%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --ring: 217.2 32.6% 17.5%;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--muted-foreground));
+  border-radius: 9999px;
+}

--- a/supabase/migrations/0001_create_schema.sql
+++ b/supabase/migrations/0001_create_schema.sql
@@ -1,0 +1,79 @@
+create extension if not exists "pgcrypto";
+
+create table profiles (
+  id uuid primary key default auth.uid(),
+  email text,
+  tz text default 'America/New_York',
+  widgets jsonb default '{
+    "order":["today","tasks","habits","gym","mood","civil","embeds"],
+    "hidden":[],
+    "settings":{}
+  }'::jsonb
+);
+alter table profiles enable row level security;
+create policy "self" on profiles for all using (id = auth.uid()) with check (id = auth.uid());
+
+create table tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references profiles(id) on delete cascade,
+  title text not null,
+  due_date date,
+  status text not null default 'todo',
+  created_at timestamptz default now(),
+  completed_at timestamptz
+);
+alter table tasks enable row level security;
+create policy "own" on tasks for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create table habits (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references profiles(id) on delete cascade,
+  name text not null,
+  goal_per_day int not null default 1,
+  created_at timestamptz default now(),
+  unique(user_id, name)
+);
+alter table habits enable row level security;
+create policy "own" on habits for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create table habit_logs (
+  id uuid primary key default gen_random_uuid(),
+  habit_id uuid not null references habits(id) on delete cascade,
+  user_id uuid not null references profiles(id) on delete cascade,
+  ts timestamptz not null default now(),
+  qty int not null default 1
+);
+alter table habit_logs enable row level security;
+create policy "own" on habit_logs for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create table moods (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references profiles(id) on delete cascade,
+  ts timestamptz default now(),
+  score int check (score between 1 and 5),
+  note text
+);
+alter table moods enable row level security;
+create policy "own" on moods for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create table workouts (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references profiles(id) on delete cascade,
+  ts timestamptz default now(),
+  bodypart text,
+  notes text
+);
+alter table workouts enable row level security;
+create policy "own" on workouts for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create table workout_sets (
+  id uuid primary key default gen_random_uuid(),
+  workout_id uuid not null references workouts(id) on delete cascade,
+  lift text, weight numeric, reps int
+);
+alter table workout_sets enable row level security;
+create policy "cascade" on workout_sets for all using (
+  exists(select 1 from workouts w where w.id = workout_sets.workout_id and w.user_id = auth.uid())
+) with check (
+  exists(select 1 from workouts w where w.id = workout_sets.workout_id and w.user_id = auth.uid())
+);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,75 @@
+import type { Config } from "tailwindcss";
+import { fontFamily } from "tailwindcss/defaultTheme";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["Inter", ...fontFamily.sans],
+      },
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
+  },
+  plugins: [require("tailwindcss-animate")],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/types/database.ts
+++ b/types/database.ts
@@ -1,0 +1,181 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      profiles: {
+        Row: {
+          id: string;
+          email: string | null;
+          tz: string | null;
+          widgets: Json | null;
+        };
+        Insert: {
+          id?: string;
+          email?: string | null;
+          tz?: string | null;
+          widgets?: Json | null;
+        };
+        Update: {
+          id?: string;
+          email?: string | null;
+          tz?: string | null;
+          widgets?: Json | null;
+        };
+      };
+      tasks: {
+        Row: {
+          id: string;
+          user_id: string;
+          title: string;
+          due_date: string | null;
+          status: string;
+          created_at: string | null;
+          completed_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          title: string;
+          due_date?: string | null;
+          status?: string;
+          created_at?: string | null;
+          completed_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          title?: string;
+          due_date?: string | null;
+          status?: string;
+          created_at?: string | null;
+          completed_at?: string | null;
+        };
+      };
+      habits: {
+        Row: {
+          id: string;
+          user_id: string;
+          name: string;
+          goal_per_day: number;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          goal_per_day?: number;
+          created_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          name?: string;
+          goal_per_day?: number;
+          created_at?: string | null;
+        };
+      };
+      habit_logs: {
+        Row: {
+          id: string;
+          habit_id: string;
+          user_id: string;
+          ts: string;
+          qty: number;
+        };
+        Insert: {
+          id?: string;
+          habit_id: string;
+          user_id: string;
+          ts?: string;
+          qty?: number;
+        };
+        Update: {
+          id?: string;
+          habit_id?: string;
+          user_id?: string;
+          ts?: string;
+          qty?: number;
+        };
+      };
+      moods: {
+        Row: {
+          id: string;
+          user_id: string;
+          ts: string | null;
+          score: number | null;
+          note: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          ts?: string | null;
+          score?: number | null;
+          note?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          ts?: string | null;
+          score?: number | null;
+          note?: string | null;
+        };
+      };
+      workouts: {
+        Row: {
+          id: string;
+          user_id: string;
+          ts: string | null;
+          bodypart: string | null;
+          notes: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          ts?: string | null;
+          bodypart?: string | null;
+          notes?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          ts?: string | null;
+          bodypart?: string | null;
+          notes?: string | null;
+        };
+      };
+      workout_sets: {
+        Row: {
+          id: string;
+          workout_id: string;
+          lift: string | null;
+          weight: number | null;
+          reps: number | null;
+        };
+        Insert: {
+          id?: string;
+          workout_id: string;
+          lift?: string | null;
+          weight?: number | null;
+          reps?: number | null;
+        };
+        Update: {
+          id?: string;
+          workout_id?: string;
+          lift?: string | null;
+          weight?: number | null;
+          reps?: number | null;
+        };
+      };
+    };
+    Views: {};
+    Functions: {};
+    Enums: {};
+  };
+}


### PR DESCRIPTION
## Summary
- implement a Next.js 14 Supabase-powered second-brain app with middleware-protected auth and iframe-friendly embed route
- add customizable drag-and-drop dashboard widgets for tasks, habits, workouts, moods, civic reminders, and external embeds with persisted settings
- include Tailwind/shadcn UI foundation plus Supabase SQL migration and type definitions

## Testing
- not run (npm dependencies not installed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3ff93331083299e7a4dce25cc0b61